### PR TITLE
add encoding utf-8 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup
 
 
-README = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
+README = open(os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8").read()
 REQUIREMENTS = [
     line.strip()
     for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt")).readlines()


### PR DESCRIPTION
According to issue-5, the problem seems to occur because the python's default encoding on Windows is cp-1252 instead of utf-8.