### PR TITLE
Fixed invalid include README.md file in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README
+include README.md
 include LICENSE
 include setup.py
 include *requirements.txt


### PR DESCRIPTION
Step to reproduce: `python setup.py egg_info`

```
running egg_info
writing pylibra.egg-info/PKG-INFO
writing dependency_links to pylibra.egg-info/dependency_links.txt
writing requirements to pylibra.egg-info/requires.txt
writing top-level names to pylibra.egg-info/top_level.txt
reading manifest file 'pylibra.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'README'
writing manifest file 'pylibra.egg-info/SOURCES.txt'
```